### PR TITLE
Support reading from 32-bit processes on 64-bit hosts and vice versa

### DIFF
--- a/src/architecture.rs
+++ b/src/architecture.rs
@@ -1,0 +1,95 @@
+use std::convert::TryInto;
+
+/// Enum representing the architecture of a process
+#[derive(Clone, Debug, Copy)]
+#[repr(u8)]
+pub enum Architecture {
+    /// 8-bit architecture
+    #[cfg(any(
+        target_pointer_width = "8",
+        target_pointer_width = "16",
+        target_pointer_width = "32",
+        target_pointer_width = "64",
+        target_pointer_width = "128"
+    ))]
+    Arch8Bit = 1,
+    /// 16-bit architecture
+    #[cfg(any(
+        target_pointer_width = "16",
+        target_pointer_width = "32",
+        target_pointer_width = "64",
+        target_pointer_width = "128"
+    ))]
+    Arch16Bit = 2,
+    /// 32-bit architecture
+    #[cfg(any(
+        target_pointer_width = "32",
+        target_pointer_width = "64",
+        target_pointer_width = "128"
+    ))]
+    Arch32Bit = 4,
+    /// 64-bit architecture
+    #[cfg(any(target_pointer_width = "64", target_pointer_width = "128"))]
+    Arch64Bit = 8,
+    /// 128-bit architecture
+    #[cfg(target_pointer_width = "128")]
+    Arch128Bit = 16,
+}
+
+impl Architecture {
+    /// Create an Architecture matching that of the host process.
+    pub fn from_native() -> Architecture {
+        #[cfg(target_pointer_width = "8")]
+        return Architecture::Arch8Bit;
+        #[cfg(target_pointer_width = "16")]
+        return Architecture::Arch16Bit;
+        #[cfg(target_pointer_width = "32")]
+        return Architecture::Arch32Bit;
+        #[cfg(target_pointer_width = "64")]
+        return Architecture::Arch64Bit;
+        #[cfg(target_pointer_width = "128")]
+        return Architecture::Arch128Bit;
+    }
+
+    /// Convert bytes read from memory into a pointer in the
+    /// current architecture.
+    pub fn pointer_from_ne_bytes(self, bytes: &[u8]) -> usize {
+        match self {
+            #[cfg(any(
+                target_pointer_width = "8",
+                target_pointer_width = "16",
+                target_pointer_width = "32",
+                target_pointer_width = "64",
+                target_pointer_width = "128"
+            ))]
+            Architecture::Arch8Bit => {
+                u8::from_ne_bytes(bytes.try_into().unwrap()) as usize
+            }
+            #[cfg(any(
+                target_pointer_width = "16",
+                target_pointer_width = "32",
+                target_pointer_width = "64",
+                target_pointer_width = "128"
+            ))]
+            Architecture::Arch16Bit => {
+                u16::from_ne_bytes(bytes.try_into().unwrap()) as usize
+            }
+            #[cfg(any(
+                target_pointer_width = "32",
+                target_pointer_width = "64",
+                target_pointer_width = "128"
+            ))]
+            Architecture::Arch32Bit => {
+                u32::from_ne_bytes(bytes.try_into().unwrap()) as usize
+            }
+            #[cfg(any(target_pointer_width = "64", target_pointer_width = "128"))]
+            Architecture::Arch64Bit => {
+                u64::from_ne_bytes(bytes.try_into().unwrap()) as usize
+            }
+            #[cfg(target_pointer_width = "128")]
+            Architecture::Arch128Bit => {
+                u128::from_ne_bytes(bytes.try_into().unwrap()) as usize
+            }
+        }
+    }
+}

--- a/src/data_member.rs
+++ b/src/data_member.rs
@@ -1,4 +1,4 @@
-use crate::{CopyAddress, Memory, ProcessHandle, PutAddress};
+use crate::{Architecture, CopyAddress, Memory, ProcessHandle, PutAddress};
 
 /// # Tools for working with memory of other programs
 /// This module provides functions for modifying the memory of a program from outside of the
@@ -27,11 +27,30 @@ use crate::{CopyAddress, Memory, ProcessHandle, PutAddress};
 /// println!("New x-value: {}", x);
 /// assert_eq!(x, 6u32);
 /// ```
+/// ```no_run
+/// # use process_memory::{Memory, DataMember, Pid, TryIntoProcessHandle, Architecture};
+/// # fn get_pid(process_name: &str) -> Pid {
+/// #     std::process::id() as Pid
+/// # }
+/// // We get a handle for a target process with a different architecture to ourselves
+/// let handle = get_pid("32Bit.exe").try_into_process_handle().unwrap();
+/// // We make a `DataMember` that has a series of offsets refering to a known value in
+/// // the target processes memory
+/// let member = DataMember::new_offset(handle, vec![0x01_02_03_04, 0x04, 0x08, 0x10])
+/// // We tell the `DataMember` that the process is a 32 bit process, and thus it should
+/// // use 32 bit pointers while traversing offsets
+///     .set_arch(Architecture::Arch32Bit);
+/// // The memory offset can now be correctly calculated:
+/// println!("Target memory location: {}", member.get_offset().unwrap());
+/// // The memory offset can now be used to retrieve and modify values:
+/// println!("Current value: {}", member.read().unwrap());
+/// member.write(&123_u32).unwrap();
+/// ```
 #[derive(Clone, Debug)]
 pub struct DataMember<T> {
     offsets: Vec<usize>,
     process: ProcessHandle,
-    arch: usize,
+    arch: Architecture,
     _phantom: std::marker::PhantomData<*mut T>,
 }
 
@@ -54,7 +73,7 @@ impl<T: Sized + Copy> DataMember<T> {
         Self {
             offsets: Vec::new(),
             process: handle,
-            arch: std::mem::size_of::<usize>() * 8,
+            arch: Architecture::from_native(),
             _phantom: std::marker::PhantomData,
         }
     }
@@ -71,7 +90,7 @@ impl<T: Sized + Copy> DataMember<T> {
         Self {
             offsets,
             process: handle,
-            arch: std::mem::size_of::<usize>() * 8,
+            arch: Architecture::from_native(),
             _phantom: std::marker::PhantomData,
         }
     }
@@ -81,8 +100,7 @@ impl<T: Sized + Copy> DataMember<T> {
     /// This can be used for reading memory offsets of programs that are of
     /// different architectures to the host program.
     /// This defaults to the architecture of the host program.
-    pub fn set_arch(mut self, arch: usize) -> Self {
-        assert!(arch == 32 || arch == 64);
+    pub fn set_arch(mut self, arch: Architecture) -> Self {
         self.arch = arch;
         self
     }
@@ -94,11 +112,11 @@ impl<T: Sized + Copy> Memory<T> for DataMember<T> {
     }
 
     fn get_offset(&self) -> std::io::Result<usize> {
-        self.process.get_offset(&self.offsets, &self.arch)
+        self.process.get_offset(&self.offsets, self.arch)
     }
 
     fn read(&self) -> std::io::Result<T> {
-        let offset = self.process.get_offset(&self.offsets, &self.arch)?;
+        let offset = self.process.get_offset(&self.offsets, self.arch)?;
         // This can't be [0_u8;size_of::<T>()] because no const generics.
         // It will be freed at the end of the function because no references are held to it.
         let mut buffer = vec![0_u8; std::mem::size_of::<T>()];
@@ -108,7 +126,7 @@ impl<T: Sized + Copy> Memory<T> for DataMember<T> {
 
     fn write(&self, value: &T) -> std::io::Result<()> {
         use std::slice;
-        let offset = self.process.get_offset(&self.offsets, &self.arch)?;
+        let offset = self.process.get_offset(&self.offsets, self.arch)?;
         let buffer: &[u8] =
             unsafe { slice::from_raw_parts(value as *const _ as _, std::mem::size_of::<T>()) };
         self.process.put_address(offset, &buffer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,25 @@
 //! println!("New x-value: {}", x);
 //! assert_eq!(x, 6_u32);
 //! ```
+//! ```no_run
+//! # use process_memory::{Memory, DataMember, Pid, TryIntoProcessHandle, Architecture};
+//! # fn get_pid(process_name: &str) -> Pid {
+//! #     std::process::id() as Pid
+//! # }
+//! // We get a handle for a target process with a different architecture to ourselves
+//! let handle = get_pid("32Bit.exe").try_into_process_handle().unwrap();
+//! // We make a `DataMember` that has a series of offsets refering to a known value in
+//! // the target processes memory
+//! let member = DataMember::new_offset(handle, vec![0x01_02_03_04, 0x04, 0x08, 0x10])
+//! // We tell the `DataMember` that the process is a 32 bit process, and thus it should
+//! // use 32 bit pointers while traversing offsets
+//!     .set_arch(Architecture::Arch32Bit);
+//! // The memory offset can now be correctly calculated:
+//! println!("Target memory location: {}", member.get_offset().unwrap());
+//! // The memory offset can now be used to retrieve and modify values:
+//! println!("Current value: {}", member.read().unwrap());
+//! member.write(&123_u32).unwrap();
+//! ```
 #![deny(missing_docs)]
 #![deny(unused_results)]
 #![deny(unreachable_pub)]
@@ -53,11 +72,11 @@
 #![deny(unused)]
 #![deny(clippy::pedantic)]
 
-use std::convert::TryInto;
-
+mod architecture;
 mod data_member;
 mod local_member;
 
+pub use architecture::Architecture;
 pub use data_member::DataMember;
 pub use local_member::LocalMember;
 
@@ -75,22 +94,21 @@ mod platform;
 /// type into a buffer.
 pub trait CopyAddress {
     /// Copy an address into user-defined buffer.
-    fn copy_address(&self, addr: usize, buf: &mut Vec<u8>) -> std::io::Result<()>;
+    fn copy_address(&self, addr: usize, buf: &mut [u8]) -> std::io::Result<()>;
 
     /// Get the actual memory location from a set of offsets.
     ///
     /// If [`copy_address`] is already defined, then we can provide a standard implementation that
     /// will work across all operating systems.
-    fn get_offset(&self, offsets: &[usize], arch: &usize) -> std::io::Result<usize> {
+    fn get_offset(&self, offsets: &[usize], arch: Architecture) -> std::io::Result<usize> {
         // Look ma! No unsafes!
         let mut offset: usize = 0;
         let noffsets: usize = offsets.len();
+        let mut copy = vec![0_u8; arch as usize];
         for next_offset in offsets.iter().take(noffsets - 1) {
             offset += next_offset;
-            let mut copy: Vec<u8> = vec![0; arch / 8];
             self.copy_address(offset, &mut copy)?;
-            copy.resize(std::mem::size_of::<usize>(), 0);
-            offset = usize::from_ne_bytes(copy.as_slice().try_into().unwrap());
+            offset = arch.pointer_from_ne_bytes(&copy);
         }
 
         offset += offsets[noffsets - 1];

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -30,7 +30,7 @@ impl TryIntoProcessHandle for Child {
 }
 
 impl CopyAddress for ProcessHandle {
-    fn copy_address(&self, addr: usize, buf: &mut Vec<u8>) -> std::io::Result<()> {
+    fn copy_address(&self, addr: usize, buf: &mut [u8]) -> std::io::Result<()> {
         let local_iov = iovec {
             iov_base: buf.as_mut_ptr() as *mut c_void,
             iov_len: buf.len(),

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -30,7 +30,7 @@ impl TryIntoProcessHandle for Child {
 }
 
 impl CopyAddress for ProcessHandle {
-    fn copy_address(&self, addr: usize, buf: &mut [u8]) -> std::io::Result<()> {
+    fn copy_address(&self, addr: usize, buf: &mut Vec<u8>) -> std::io::Result<()> {
         let local_iov = iovec {
             iov_base: buf.as_mut_ptr() as *mut c_void,
             iov_len: buf.len(),

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -61,7 +61,7 @@ impl PutAddress for ProcessHandle {
 /// We use `vm_read_overwrite` instead of `vm_read` because it can handle non-aligned reads and
 /// won't read an entire page.
 impl CopyAddress for ProcessHandle {
-    fn copy_address(&self, addr: usize, buf: &mut Vec<u8>) -> std::io::Result<()> {
+    fn copy_address(&self, addr: usize, buf: &mut [u8]) -> std::io::Result<()> {
         let mut read_len: u64 = 0;
         let result = unsafe {
             mach::vm::mach_vm_read_overwrite(

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -61,14 +61,14 @@ impl PutAddress for ProcessHandle {
 /// We use `vm_read_overwrite` instead of `vm_read` because it can handle non-aligned reads and
 /// won't read an entire page.
 impl CopyAddress for ProcessHandle {
-    fn copy_address(&self, addr: usize, buf: &mut [u8]) -> std::io::Result<()> {
+    fn copy_address(&self, addr: usize, buf: &mut Vec<u8>) -> std::io::Result<()> {
         let mut read_len: u64 = 0;
         let result = unsafe {
             mach::vm::mach_vm_read_overwrite(
                 *self,
                 addr as _,
                 buf.len() as _,
-                buf.as_ptr() as _,
+                buf.as_mut_ptr() as _,
                 &mut read_len,
             )
         };

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,7 +1,6 @@
 use winapi;
 use winapi::shared::minwindef;
 
-use std::mem;
 use std::os::windows::io::AsRawHandle;
 use std::process::Child;
 use std::ptr;
@@ -54,7 +53,7 @@ impl TryIntoProcessHandle for Child {
 
 /// Use `ReadProcessMemory` to read memory from another process on Windows.
 impl CopyAddress for ProcessHandle {
-    fn copy_address(&self, addr: usize, buf: &mut Vec<u8>) -> std::io::Result<()> {
+    fn copy_address(&self, addr: usize, buf: &mut [u8]) -> std::io::Result<()> {
         if buf.is_empty() {
             return Ok(());
         }
@@ -87,7 +86,7 @@ impl PutAddress for ProcessHandle {
                 *self,
                 addr as minwindef::LPVOID,
                 buf.as_ptr() as minwindef::LPCVOID,
-                mem::size_of_val(buf) as winapi::shared::basetsd::SIZE_T,
+                buf.len() as winapi::shared::basetsd::SIZE_T,
                 ptr::null_mut(),
             )
         } == winapi::shared::minwindef::FALSE

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -54,7 +54,7 @@ impl TryIntoProcessHandle for Child {
 
 /// Use `ReadProcessMemory` to read memory from another process on Windows.
 impl CopyAddress for ProcessHandle {
-    fn copy_address(&self, addr: usize, buf: &mut [u8]) -> std::io::Result<()> {
+    fn copy_address(&self, addr: usize, buf: &mut Vec<u8>) -> std::io::Result<()> {
         if buf.is_empty() {
             return Ok(());
         }
@@ -64,7 +64,7 @@ impl CopyAddress for ProcessHandle {
                 *self,
                 addr as minwindef::LPVOID,
                 buf.as_mut_ptr() as minwindef::LPVOID,
-                mem::size_of_val(buf) as winapi::shared::basetsd::SIZE_T,
+                buf.len() as winapi::shared::basetsd::SIZE_T,
                 ptr::null_mut(),
             )
         } == winapi::shared::minwindef::FALSE


### PR DESCRIPTION
Support setting the architecture of a DataMember to either 32 or 64 bit, defaulting to the pointer size of the host program.
Currently this setting only affects the traversal via `get_offset()`, but I had to make modifications to `copy_address()` due to https://github.com/rust-lang/rust/issues/50824

I'm new to rust so let me know if I can improve anything.