### PR TITLE
Support negative offsets, getting module base, and get_pid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,4 @@ libc = "0.2"
 mach = "0.3"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winnt", "memoryapi", "minwindef", "processthreadsapi"] }
+winapi = { version = "0.3", features = ["winnt", "memoryapi", "minwindef", "processthreadsapi", "handleapi"] }

--- a/examples/fastyboy.rs
+++ b/examples/fastyboy.rs
@@ -66,13 +66,13 @@ fn main() -> std::io::Result<()> {
     let process_handle = get_pid("MirrorsEdgeCatalyst.exe").try_into_process_handle()?;
 
     let mut spawn_timer = DataMember::<f32>::new(process_handle);
-    spawn_timer.set_offset(vec![0x1_42_14_2a_d8, 0xac]);
+    spawn_timer.set_offset(0x1_42_14_2a_d8, vec![0xac]);
 
     let mut level_warmup = DataMember::<f32>::new(process_handle);
-    level_warmup.set_offset(vec![0x1_42_14_2a_d8, 0x9c]);
+    level_warmup.set_offset(0x1_42_14_2a_d8, vec![0x9c]);
 
     let mut emitters_enabled = DataMember::<bool>::new(process_handle);
-    emitters_enabled.set_offset(vec![0x1_42_3e_44_78, 0xac]);
+    emitters_enabled.set_offset(0x1_42_3e_44_78, vec![0xac]);
 
     spawn_timer.write(&1.0)?;
     level_warmup.write(&1.0)?;

--- a/examples/fastyboy.rs
+++ b/examples/fastyboy.rs
@@ -15,55 +15,10 @@ fn main() {
     println!("FastyBoy can only be run on systems supporting the game Mirror's Edge Catalyst, which as of writing is only Windows.")
 }
 
-/// A helper function to get a Pid from the name of a process
-#[cfg(windows)]
-pub fn get_pid(process_name: &str) -> process_memory::Pid {
-    /// A helper function to turn a c_char array to a String
-    fn utf8_to_string(bytes: &[i8]) -> String {
-        use std::ffi::CStr;
-        unsafe {
-            CStr::from_ptr(bytes.as_ptr())
-                .to_string_lossy()
-                .into_owned()
-        }
-    }
-    let mut entry = winapi::um::tlhelp32::PROCESSENTRY32 {
-        dwSize: std::mem::size_of::<winapi::um::tlhelp32::PROCESSENTRY32>() as u32,
-        cntUsage: 0,
-        th32ProcessID: 0,
-        th32DefaultHeapID: 0,
-        th32ModuleID: 0,
-        cntThreads: 0,
-        th32ParentProcessID: 0,
-        pcPriClassBase: 0,
-        dwFlags: 0,
-        szExeFile: [0; winapi::shared::minwindef::MAX_PATH],
-    };
-    let snapshot: winapi::um::winnt::HANDLE;
-    unsafe {
-        snapshot = winapi::um::tlhelp32::CreateToolhelp32Snapshot(
-            winapi::um::tlhelp32::TH32CS_SNAPPROCESS,
-            0,
-        );
-        if winapi::um::tlhelp32::Process32First(snapshot, &mut entry)
-            == winapi::shared::minwindef::TRUE
-        {
-            while winapi::um::tlhelp32::Process32Next(snapshot, &mut entry)
-                == winapi::shared::minwindef::TRUE
-            {
-                if utf8_to_string(&entry.szExeFile) == process_name {
-                    return entry.th32ProcessID;
-                }
-            }
-        }
-    }
-    0
-}
-
 #[cfg(windows)]
 fn main() -> std::io::Result<()> {
     use process_memory::*;
-    let process_handle = get_pid("MirrorsEdgeCatalyst.exe").try_into_process_handle()?;
+    let process_handle = get_pid("MirrorsEdgeCatalyst.exe")?.try_into_process_handle()?;
 
     let mut spawn_timer = DataMember::<f32>::new(process_handle);
     spawn_timer.set_offset(0x1_42_14_2a_d8, vec![0xac]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ pub trait CopyAddress {
     ///
     /// # Errors
     /// `std::io::Error` if an error occurs copying the address.
+    #[allow(clippy::cast_sign_loss)]
     fn get_offset(&self, base: usize, offsets: &[isize]) -> std::io::Result<usize> {
         // Look ma! No unsafes!
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,22 @@ pub trait ProcessHandleExt {
     fn set_arch(self, arch: Architecture) -> Self;
 }
 
+/// Handling modules (e.g. DLLs) in a process.
+pub trait ModuleInfo {
+    /// Gets the base address of a module in a process. For example, "GameAssembly.dll" when on Windows.
+    /// You can then use the address in the `base` parameter of [`set_offset`] for example.
+    /// 
+    /// # Errors
+    /// Returns `std::io::ErrorKind::NotFound` when no such module name exists.
+    /// Returns OS Error when something else went wrong.
+    /// 
+    /// # Panics
+    /// Panics when closing the handle fails (e.g. double close).
+    ///
+    /// [`set_offset`]: trait.Memory.html#tymethod.set_offset
+    fn get_module_base(&self, name: &str) -> std::io::Result<usize>;
+}
+
 /// A trait that refers to and allows writing to a region of memory in a running program.
 pub trait Memory<T> {
     /// Set the offsets to the location in memory. This is used for things such as multi-level

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,9 @@ mod platform;
 #[path = "windows.rs"]
 mod platform;
 
+#[cfg(windows)]
+pub use platform::get_pid;
+
 /// A trait that defines that it is possible to copy some memory from something represented by a
 /// type into a buffer.
 pub trait CopyAddress {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,11 +203,11 @@ pub trait ProcessHandleExt {
 pub trait ModuleInfo {
     /// Gets the base address of a module in a process. For example, "GameAssembly.dll" when on Windows.
     /// You can then use the address in the `base` parameter of [`set_offset`] for example.
-    /// 
+    ///
     /// # Errors
     /// Returns `std::io::ErrorKind::NotFound` when no such module name exists.
     /// Returns OS Error when something else went wrong.
-    /// 
+    ///
     /// # Panics
     /// Panics when closing the handle fails (e.g. double close).
     ///
@@ -308,15 +308,24 @@ mod tests {
         let game = GameState {
             garbage: 42,
             garbage2: 1337,
-            players: [Box::new(Player {x:1, y:2}), Box::new(Player {x:3, y:4})],
+            players: [
+                Box::new(Player { x: 1, y: 2 }),
+                Box::new(Player { x: 3, y: 4 }),
+            ],
         };
-        let handle = (std::process::id() as Pid).try_into_process_handle().unwrap();
+        let handle = (std::process::id() as Pid)
+            .try_into_process_handle()
+            .unwrap();
 
-        let garbage2 = DataMember::<u32>::new_addr_offset(handle, &game as *const _ as usize, vec![4]);
+        let garbage2 =
+            DataMember::<u32>::new_addr_offset(handle, &game as *const _ as usize, vec![4]);
         assert_eq!(1337, garbage2.read().unwrap());
 
-        let second_player = DataMember::<Player>::new_addr_offset(handle, &game as *const _ as usize,
-            vec![8 + (handle.get_pointer_width() as u8 as isize) * 1]); // skip u32 + i64 + first player.
+        let second_player = DataMember::<Player>::new_addr_offset(
+            handle,
+            &game as *const _ as usize,
+            vec![8 + (handle.get_pointer_width() as u8 as isize) * 1],
+        ); // skip u32 + i64 + first player.
 
         let second_player_x = second_player.extend::<u32>(vec![0]);
         let second_player_y = second_player.extend::<u32>(vec![4]); // sizeof u32

--- a/src/local_member.rs
+++ b/src/local_member.rs
@@ -85,6 +85,7 @@ impl<T: Sized + Copy> Memory<T> for LocalMember<T> {
         self.offsets = new_offsets;
     }
 
+    #[allow(clippy::cast_sign_loss)]
     fn get_offset(&self) -> std::io::Result<usize> {
         if self.offsets.is_empty() {
             Ok(self.base)

--- a/src/local_member.rs
+++ b/src/local_member.rs
@@ -86,7 +86,9 @@ impl<T: Sized + Copy> Memory<T> for LocalMember<T> {
     }
 
     fn get_offset(&self) -> std::io::Result<usize> {
-        if !self.offsets.is_empty() {
+        if self.offsets.is_empty() {
+            Ok(self.base)
+        } else {
             let mut offset = self.base;
             for i in 0..self.offsets.len() - 1 {
                 offset = offset.wrapping_add(self.offsets[i] as usize); // should work because of 2s-complement
@@ -104,8 +106,6 @@ impl<T: Sized + Copy> Memory<T> for LocalMember<T> {
                 }
             }
             Ok(offset.wrapping_add(self.offsets[self.offsets.len() - 1] as usize))
-        } else {
-            Ok(self.base)
         }
     }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,7 +4,7 @@ use std::os::windows::io::AsRawHandle;
 use std::process::Child;
 use std::ptr;
 
-use super::{Architecture, CopyAddress, ProcessHandleExt, PutAddress, TryIntoProcessHandle};
+use super::{Architecture, CopyAddress, ProcessHandleExt, PutAddress, TryIntoProcessHandle, ModuleInfo};
 
 /// On Windows a `Pid` is a `DWORD`.
 pub type Pid = minwindef::DWORD;
@@ -104,6 +104,87 @@ impl PutAddress for ProcessHandle {
             Err(std::io::Error::last_os_error())
         } else {
             Ok(())
+        }
+    }
+}
+
+/// Use `CreateToolhelp32Snapshot` to get and filter list of loaded modules (called DLLs in Windows)
+/// of this process, returning the base address of it.
+impl ModuleInfo for Pid {
+    fn get_module_base(&self, name: &str) -> std::io::Result<usize> {
+        // taken from https://stackoverflow.com/questions/41552466/how-do-i-get-the-physical-baseaddress-of-an-dll-used-in-a-process
+        use winapi::um::{handleapi::CloseHandle, tlhelp32::{self, TH32CS_SNAPMODULE, TH32CS_SNAPMODULE32}};
+        use minwindef::{TRUE, FALSE};
+
+        let mut module_entry = tlhelp32::MODULEENTRY32 {
+            dwSize: 0,
+            th32ModuleID: 0,
+            th32ProcessID: 0,
+            GlblcntUsage: 0,
+            ProccntUsage: 0,
+            modBaseAddr: std::ptr::null_mut(), // yikes
+            modBaseSize: 0,
+            hModule: std::ptr::null_mut(), // yikes
+            szModule: [0; tlhelp32::MAX_MODULE_NAME32 + 1],
+            szExePath: [0; winapi::shared::minwindef::MAX_PATH]
+        };
+
+        unsafe {
+            module_entry.dwSize = std::mem::size_of::<tlhelp32::MODULEENTRY32>() as u32;
+
+            let snapshot = tlhelp32::CreateToolhelp32Snapshot(TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, *self);
+            if snapshot.is_null() {
+                return Err(std::io::Error::last_os_error());
+            }
+
+            if tlhelp32::Module32First(snapshot, &mut module_entry) == TRUE {
+                // makeshift do-while
+                loop {
+                    println!("Have module: {}", utf8_to_string(&module_entry.szModule));
+                    if utf8_to_string(&module_entry.szModule) == name {
+                        if CloseHandle(snapshot) == FALSE { panic!("Could not close handle") };
+                        return Ok(module_entry.modBaseAddr as usize);
+                    }
+
+                    if tlhelp32::Module32Next(snapshot, &mut module_entry) != TRUE { break; }
+                }
+            }
+
+            // We searched everything, nothing found
+            if CloseHandle(snapshot) == FALSE { panic!("Could not close handle") };
+            return Err(std::io::Error::new(std::io::ErrorKind::NotFound, format!("Process PID#{} contains no module named \"{}\".", *self, name)));
+        }
+    }
+}
+
+/// A helper function to turn a c_char array to a String
+fn utf8_to_string(bytes: &[i8]) -> String {
+    use std::ffi::CStr;
+    unsafe {
+        CStr::from_ptr(bytes.as_ptr())
+            .to_string_lossy()
+            .into_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::ErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn module_info() {
+        let pid = std::process::id() as Pid;
+        let base = pid.get_module_base("ntdll.dll").unwrap();
+        assert_ne!(0, base);
+        // println!("ntdll.exe address: 0x{:X}", base);
+
+        match pid.get_module_base("this_dll_doesnt_exist.dll") {
+            Ok(_) => panic!(),
+            Err(e) => {
+                assert_eq!(ErrorKind::NotFound, e.kind());
+            }
         }
     }
 }


### PR DESCRIPTION
Bit of a two-in-one PR, I can split it up if you'd prefer.

Since CheatEngine allows you to have negative offsets (and I needed that), I added support for them. Because having everything be `isize` seemed a bit iffy, there's a new `base` field in `DataMember` and `LocalMember` etc, which is usize, and is now what used to be the first offset.

I've also added two convenience functions, `get_pid()` because of course, and the `ModuleInfo` trait to facilitate stuff such as `GameAssembly.dll + 0x11223344`.

Sadly I only have enough experience (and motivation) to do this for Windows, sorry :(.
Hope I didn't forget anything.
