### PR TITLE
Add new DataMember constructors, extend, shift.

### DIFF
--- a/src/architecture.rs
+++ b/src/architecture.rs
@@ -89,4 +89,10 @@ impl Architecture {
             Architecture::Arch128Bit => u128::from_ne_bytes(bytes.try_into().unwrap()) as usize,
         }
     }
+
+    /// Returns the amount of bytes which a pointer takes up on this architecture.
+    /// E.g. 4 for 32bit, 8 for 64bit, etc.
+    pub fn pointer_width_bytes(self) -> usize {
+        self as u8 as usize
+    }
 }

--- a/src/data_member.rs
+++ b/src/data_member.rs
@@ -72,6 +72,100 @@ impl<T: Sized + Copy> DataMember<T> {
             _phantom: std::marker::PhantomData,
         }
     }
+
+    /// Create a new `DataMember` from a [`ProcessHandle`] and some number of (potentially negative) offsets.
+    /// You must remember to call [`try_into_process_handle`] on a [`Pid`] as sometimes the `Pid` can have
+    /// the same backing type as a [`ProcessHandle`], resulting in an error.
+    ///
+    /// [`try_into_process_handle`]: trait.TryIntoProcessHandle.html#tymethod.try_into_process_handle
+    /// [`ProcessHandle`]: type.ProcessHandle.html
+    /// [`Pid`]: type.Pid.htm
+    #[must_use]
+    pub fn new_offset_relative(handle: ProcessHandle, offsets: Vec<isize>) -> Self {
+        Self {
+            // Yes, we are casting to usize. This will not touch any bits, but due to 2s complement,
+            // we still get the correct result when adding offsets.
+            offsets: offsets.into_iter().map(|x| x as usize).collect(),
+            process: handle,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Create a new `DataMember` from a [`ProcessHandle`], pointing to the memory address in the
+    /// remote process. Equivalent to `new_offset(handle, vec![addr])`. You must
+    /// remember to call [`try_into_process_handle`] on a [`Pid`] as sometimes the `Pid` can have
+    /// the same backing type as a [`ProcessHandle`], resulting in an error.
+    ///
+    /// [`try_into_process_handle`]: trait.TryIntoProcessHandle.html#tymethod.try_into_process_handle
+    /// [`ProcessHandle`]: type.ProcessHandle.html
+    /// [`Pid`]: type.Pid.html
+    #[must_use]
+    pub fn new_addr(handle: ProcessHandle, addr: usize) -> Self {
+        Self {
+            offsets: vec![addr],
+            process: handle,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Create a new `DataMember` from a [`ProcessHandle`], pointing to the memory address in the
+    /// process, then following a bunch of pointers and offsets, which may be negative.
+    /// If you use CheatEngine and get a pointer of form "MyModule.dll + 0x12345678", plus a bunch
+    /// of offsets, then you want to put the base address of the module as `addr`, `0x12345678` as
+    /// the first offset, then any further offsets etc.
+    /// This function is merely a convenience function, and is equivalent to
+    /// `new_offset_relative(handle, vec![addr as isize, offsets[0], offsets[1], ...])`.
+    /// You must
+    /// remember to call [`try_into_process_handle`] on a [`Pid`] as sometimes the `Pid` can have
+    /// the same backing type as a [`ProcessHandle`], resulting in an error.
+    ///
+    /// [`try_into_process_handle`]: trait.TryIntoProcessHandle.html#tymethod.try_into_process_handle
+    /// [`ProcessHandle`]: type.ProcessHandle.html
+    /// [`Pid`]: type.Pid.html
+    #[must_use]
+    pub fn new_addr_offset(handle: ProcessHandle, addr: usize, offsets: Vec<isize>) -> Self {
+        let mut vec = vec![addr];
+        // Yes, we are casting to usize. This will not touch any bits, and due to 2s complement,
+        // we still get the correct result when adding offsets.
+        vec.extend(offsets.into_iter().map(|x| x as usize));
+        Self {
+            offsets: vec,
+            process: handle,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Creates a new `DataMember` by appending some more offets. Useful when you have a data
+    /// structure, and want to refer to multiple fields in it, or use it as a starting point
+    /// for chasing down more pointers.
+    /// Since the pointed-to data type might have changed, this function is generic. It is your
+    /// responsibility to make sure you know what you point to.
+    #[must_use]
+    pub fn extend<TNew>(&self, more_offsets: Vec<isize>) -> DataMember<TNew> {
+        let mut clone = DataMember {
+            offsets: self.offsets.clone(),
+            process: self.process,
+            _phantom: std::marker::PhantomData,
+        };
+        // Yes, we are casting to usize. This will not touch any bits, and due to 2s complement,
+        // we still get the correct result when adding offsets.
+        clone.offsets.extend(more_offsets.into_iter().map(|x| x as usize));
+        clone
+    }
+
+    /// Creates a new `DataMember`, based on self, by shifting the last offset by a number of
+    /// bytes. Does not append new offsets. This is useful if you have a pointer to a struct
+    /// and want to address different fields, or access elements in an array.
+    pub fn shift<TNew>(&self, n_bytes: isize) -> DataMember<TNew> {
+        let mut clone = DataMember {
+            offsets: self.offsets.clone(),
+            process: self.process,
+            _phantom: std::marker::PhantomData,
+        };
+        let new = clone.offsets[self.offsets.len() - 1].wrapping_add(n_bytes as usize);
+        clone.offsets[self.offsets.len() - 1] = new;
+        clone
+    }
 }
 
 impl<T: Sized + Copy> Memory<T> for DataMember<T> {
@@ -146,5 +240,59 @@ mod test {
         assert_eq!(test, member.read().unwrap());
         member.write(&0xffff).unwrap();
         assert_eq!(test, 0xffff);
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct Player {
+        x: u32,
+        y: u32,
+    }
+
+    #[repr(C)]
+    struct GameState {
+        garbage: u32,
+        garbage2: u32,
+        players: [Box<Player>; 2], // note that this array is in-place, since it's fixed size.
+    }
+
+    #[test]
+    fn multilevel_pointers() {
+        let game = GameState {
+            garbage: 42,
+            garbage2: 1337,
+            players: [
+                Box::new(Player { x: 1, y: 2 }),
+                Box::new(Player { x: 3, y: 4 }),
+            ],
+        };
+        let handle = (std::process::id() as crate::Pid)
+            .try_into_process_handle()
+            .unwrap();
+
+        // point to `game`, then our data is +4 from the base of `game`.
+        let garbage2 =
+            DataMember::<u32>::new_addr(handle, &game as *const _ as usize + 4);
+        assert_eq!(1337, garbage2.read().unwrap());
+
+        let garbage1 = garbage2.shift(-4);
+        assert_eq!(42u32, garbage1.read().unwrap());
+
+        // At `game + 2*sizeof(u32) + 1*sizeof(Player*) is where we find 
+        // a pointer to the second player.
+        // So second_player.read() right now would just get you the pointer to the player.
+        let second_player = DataMember::<*mut Player>::new_addr(
+            handle,
+            (&game as *const _ as usize) + 8 + handle.get_pointer_width().pointer_width_bytes(),
+        );
+
+        // But when we add an offset, in this case an offset of 0, we follow the pointer,
+        // and thus second_player_x points to the beginning of the second player, which in this
+        // case is also the x coordinate.
+        let second_player_x = second_player.extend::<u32>(vec![0]);
+        let second_player_y = second_player.extend::<u32>(vec![4]); // sizeof u32 = 4
+
+        assert_eq!(3, second_player_x.read().unwrap());
+        assert_eq!(4, second_player_y.read().unwrap());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,12 +115,12 @@ pub trait CopyAddress {
         let noffsets: usize = offsets.len();
         let mut copy = vec![0_u8; self.get_pointer_width() as usize];
         for next_offset in offsets.iter().take(noffsets - 1) {
-            offset += next_offset;
+            offset = offset.wrapping_add(*next_offset);
             self.copy_address(offset, &mut copy)?;
             offset = self.get_pointer_width().pointer_from_ne_bytes(&copy);
         }
 
-        offset += offsets[noffsets - 1];
+        offset = offset.wrapping_add(offsets[noffsets - 1]);
         Ok(offset)
     }
 


### PR DESCRIPTION
Since the requested changes on https://github.com/Tommoa/rs-process-memory/pull/4 would have required me to undo a lot of stuff, I decided to make some new pull requests.

This is a small one, mostly just for convenience.