### PR TITLE
Replaced dependency 'winapi' with the official windows api projection crate 'windows' by microsoft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 **/*.rs.bk
 Cargo.lock
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /target/
 **/*.rs.bk
 Cargo.lock
-.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,11 @@ edition = "2018"
 name = "fastyboy"
 crate-type = ["bin"]
 
+# Feature needed in the fastyboy example to get the pid of a process by name
 [target.'cfg(windows)'.dev-dependencies]
-winapi = { version = "0.3", features = ["tlhelp32"] }
+windows = { version = "0.43.0", features = [
+    "Win32_System_Diagnostics_ToolHelp",
+] }
 
 [dependencies]
 libc = "0.2"
@@ -22,4 +25,8 @@ libc = "0.2"
 mach = "0.3"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winnt", "memoryapi", "minwindef", "processthreadsapi"] }
+windows = { version = "0.43.0", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_Diagnostics_Debug",
+] }

--- a/examples/fastyboy.rs
+++ b/examples/fastyboy.rs
@@ -5,7 +5,7 @@
 //! "level warmup time" to 1 second (also down from a default of 10 seconds) and disables emitters.
 //! These modifications should make the time taken to load a level in Mirror's Edge Catalyst
 //! significantly shorter.
-
+#[cfg(windows)]
 mod windows {
     pub(crate) use windows::Win32::{
         Foundation::{CHAR, MAX_PATH},
@@ -46,7 +46,8 @@ pub fn get_pid(process_name: &str) -> process_memory::Pid {
         szExeFile: [windows::CHAR(0); windows::MAX_PATH as usize],
     };
     unsafe {
-        // On Error return 0 as the pid. Maybe this function should instead return itself a Result to indicate if a pid has been found?
+        // On Error return 0 as the pid. Maybe this function should instead return itself a Result
+        // to indicate if a pid has been found?
         let snapshot = if let Ok(snapshot) =
             windows::CreateToolhelp32Snapshot(windows::TH32CS_SNAPPROCESS, 0)
         {

--- a/examples/fastyboy.rs
+++ b/examples/fastyboy.rs
@@ -6,10 +6,15 @@
 //! These modifications should make the time taken to load a level in Mirror's Edge Catalyst
 //! significantly shorter.
 
-extern crate process_memory;
-#[cfg(windows)]
-extern crate winapi;
-
+mod windows {
+    pub(crate) use windows::Win32::{
+        Foundation::{CHAR, MAX_PATH},
+        System::Diagnostics::ToolHelp::{
+            CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32,
+            TH32CS_SNAPPROCESS,
+        },
+    };
+}
 #[cfg(not(windows))]
 fn main() {
     println!("FastyBoy can only be run on systems supporting the game Mirror's Edge Catalyst, which as of writing is only Windows.")
@@ -18,17 +23,18 @@ fn main() {
 /// A helper function to get a Pid from the name of a process
 #[cfg(windows)]
 pub fn get_pid(process_name: &str) -> process_memory::Pid {
-    /// A helper function to turn a c_char array to a String
-    fn utf8_to_string(bytes: &[i8]) -> String {
+    /// A helper function to turn a CHAR array to a String
+    fn utf8_to_string(bytes: &[windows::CHAR]) -> String {
         use std::ffi::CStr;
         unsafe {
-            CStr::from_ptr(bytes.as_ptr())
+            CStr::from_ptr(bytes.as_ptr() as *const i8)
                 .to_string_lossy()
                 .into_owned()
         }
     }
-    let mut entry = winapi::um::tlhelp32::PROCESSENTRY32 {
-        dwSize: std::mem::size_of::<winapi::um::tlhelp32::PROCESSENTRY32>() as u32,
+
+    let mut entry = windows::PROCESSENTRY32 {
+        dwSize: std::mem::size_of::<windows::PROCESSENTRY32>() as u32,
         cntUsage: 0,
         th32ProcessID: 0,
         th32DefaultHeapID: 0,
@@ -37,20 +43,19 @@ pub fn get_pid(process_name: &str) -> process_memory::Pid {
         th32ParentProcessID: 0,
         pcPriClassBase: 0,
         dwFlags: 0,
-        szExeFile: [0; winapi::shared::minwindef::MAX_PATH],
+        szExeFile: [windows::CHAR(0); windows::MAX_PATH as usize],
     };
-    let snapshot: winapi::um::winnt::HANDLE;
     unsafe {
-        snapshot = winapi::um::tlhelp32::CreateToolhelp32Snapshot(
-            winapi::um::tlhelp32::TH32CS_SNAPPROCESS,
-            0,
-        );
-        if winapi::um::tlhelp32::Process32First(snapshot, &mut entry)
-            == winapi::shared::minwindef::TRUE
+        // On Error return 0 as the pid. Maybe this function should instead return itself a Result to indicate if a pid has been found?
+        let snapshot = if let Ok(snapshot) =
+            windows::CreateToolhelp32Snapshot(windows::TH32CS_SNAPPROCESS, 0)
         {
-            while winapi::um::tlhelp32::Process32Next(snapshot, &mut entry)
-                == winapi::shared::minwindef::TRUE
-            {
+            snapshot
+        } else {
+            return 0;
+        };
+        if windows::Process32First(snapshot, &mut entry) == true {
+            while windows::Process32Next(snapshot, &mut entry) == true {
                 if utf8_to_string(&entry.szExeFile) == process_name {
                     return entry.th32ProcessID;
                 }


### PR DESCRIPTION
I don't know if such Pull Requests out of the blue are appreciated or not, so if you don't want to merge it please feel free to simply deny or ignore it.

This PR replaces the dependency '[winapi](https://crates.io/crates/winapi)' with the official windows api projection '[windows](https://crates.io/crates/windows)'. 
This has multiple benefits:

1. The official projection is actively maintained while winapi had the last update 1 years ago
2. The official projection [seems to be more complete](https://www.reddit.com/r/rust/comments/l23fr7/comment/gk3n3eg/?utm_source=share&utm_medium=web2x&context=3)
3. The official projection is generated automatically from metadata about the windows api, which can express more semantic information than the C api provides. This can for example be seen in file 'windows.rs' on lines 47-60, where `OpenProcess` returns a `Result` instead of a "0-HANDLE".